### PR TITLE
Pin to specific test image to avoid cache issues

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -55,7 +55,7 @@ pipeline:
       branch: master
       event: push
   e2e_test:
-    image: quay.io/ukhomeofficedigital/lev-api-test:v${MAJOR}.${MINOR}
+    image: quay.io/ukhomeofficedigital/lev-api-test:v${MAJOR}.${MINOR}.${PATCH}
     secrets:
       - USERNAME
       - PASSWORD


### PR DESCRIPTION
Temporarily pin to a specific patch version of the test image to avoid a
problem with Drone.io's cache. In the future we should be able to revert
this.