### PR TITLE
Don't pin to PATCH version of the test image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -58,7 +58,7 @@ pipeline:
       - $${kubectl} set image "deployment/$${KUBE_DEPLOYMENT}" "$${KUBE_CONTAINER}=${DOCKER_REPO}/${NAME}:$${TAG}"
       - $${kubectl} rollout status "deployment/$${KUBE_DEPLOYMENT}"
       - $${kubectl} scale deployment "$${KUBE_DEPLOYMENT}" --replicas 1
-      - docker run --env "USERNAME=$${USERNAME}" --env "PASSWORD=$${PASSWORD}" --env "CLIENT_ID=$${CLIENT_ID}" --env "CLIENT_SECRET=$${CLIENT_SECRET}" --env "OIDC_URL=$${OIDC_URL}" --env "TEST_URL=$${TEST_URL}" quay.io/ukhomeofficedigital/lev-api-test:v${MAJOR}.${MINOR}.${PATCH}
+      - docker run --env "USERNAME=$${USERNAME}" --env "PASSWORD=$${PASSWORD}" --env "CLIENT_ID=$${CLIENT_ID}" --env "CLIENT_SECRET=$${CLIENT_SECRET}" --env "OIDC_URL=$${OIDC_URL}" --env "TEST_URL=$${TEST_URL}" quay.io/ukhomeofficedigital/lev-api-test:v${MAJOR}.${MINOR}
     when:
       branch: master
       event: push


### PR DESCRIPTION
In theory, we should be able to just test with whatever MINOR version we
claim to support.