### PR TITLE
Refactor metrics support 

### DIFF
--- a/src/lib/metrics.js
+++ b/src/lib/metrics.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const moment = require('moment');
+const HotShots = require('hot-shots');
+const statsdClient = new HotShots();
+
+const validDataSets = [
+  'birth',
+  'death',
+  'marriage'
+];
+
+const validateCommon = (dataSet, username, client, groups, startTime, finishTime) => {
+  if (dataSet === undefined) {
+    throw ReferenceError('First argument, dataSet, was not defined');
+  } else if (typeof dataSet !== 'string') {
+    throw TypeError('First argument, dataSet, was not a string');
+  } else if (!validDataSets.includes(dataSet)) {
+    throw RangeError('First argument, dataSet, was not recognised');
+  }
+
+  if (username === undefined) {
+    throw ReferenceError('Second argument, username, was not defined');
+  } else if (typeof username !== 'string') {
+    throw TypeError('Second argument, username, was not a string');
+  }
+
+  if (client === undefined) {
+    throw ReferenceError('Third argument, client, was not defined');
+  } else if (typeof client !== 'string') {
+    throw TypeError('Third argument, client, was not a string');
+  }
+
+  if (groups === undefined) {
+    throw ReferenceError('Forth argument, groups, was not defined');
+  } else if (!(groups instanceof Array)) {
+    throw TypeError('Forth argument, groups, was not an array');
+  }
+
+  if (startTime === undefined) {
+    throw ReferenceError('Fifth argument, startTime, was not defined');
+  } else if (!(startTime instanceof moment)) {
+    throw TypeError('Fifth argument, startTime, was not a moment object');
+  }
+
+  if (finishTime === undefined) {
+    throw ReferenceError('Sixth argument, finishTime, was not defined');
+  } else if (!(finishTime instanceof moment)) {
+    throw TypeError('Sixth argument, finishTime, was not a moment object');
+  }
+};
+
+const statsd = (reqType, dataSet, username, client, groups, duration) => {
+  const statsdPrefix = 'lev.api';
+
+  statsdClient.increment(`${statsdPrefix}.req`);
+  statsdClient.increment(`${statsdPrefix}.req.${reqType}`);
+  statsdClient.increment(`${statsdPrefix}.req.${dataSet}`);
+  statsdClient.increment(`${statsdPrefix}.req.${client}`);
+  groups.forEach(g => statsdClient.increment(`${statsdPrefix}.req.${g}`));
+
+  statsdClient.timing(`${statsdPrefix}.req.time`, duration);
+  statsdClient.timing(`${statsdPrefix}.req.${reqType}.time`, duration);
+  statsdClient.timing(`${statsdPrefix}.req.${dataSet}.time`, duration);
+  statsdClient.timing(`${statsdPrefix}.req.${client}.time`, duration);
+  groups.forEach(g => statsdClient.timing(`${statsdPrefix}.req.${g}.time`, duration));
+
+  statsdClient.set(`${statsdPrefix}.req.users`, username);
+  statsdClient.set(`${statsdPrefix}.req.${reqType}.users`, username);
+  statsdClient.set(`${statsdPrefix}.req.${dataSet}.users`, username);
+  statsdClient.set(`${statsdPrefix}.req.${client}.users`, username);
+  groups.forEach(g => statsdClient.set(`${statsdPrefix}.req.${g}.users`, username));
+};
+
+const lookup = (dataSet, username, client, groups, startTime, finishTime, id) => {
+  validateCommon(dataSet, username, client, groups, startTime, finishTime);
+
+  if (id === undefined) {
+    throw ReferenceError('Seventh argument, id, was not defined');
+  } else if (!Number.isInteger(id)) {
+    throw TypeError('Seventh argument, id, was not an integer');
+  } else if (id < 0) {
+    throw RangeError('Seventh argument, id, was not a positive integer');
+  }
+
+  const duration = finishTime.diff(startTime);
+
+  statsd('lookup', dataSet, username, client, groups, duration);
+};
+
+const search = (dataSet, username, client, groups, startTime, finishTime, query) => {
+  validateCommon(dataSet, username, client, groups, startTime, finishTime);
+
+  if (query === undefined) {
+    throw ReferenceError('Seventh argument, query, was not defined');
+  } else if (!(query instanceof Object)) {
+    throw TypeError('Seventh argument, query, was not an object');
+  }
+
+  const duration = finishTime.diff(startTime);
+
+  statsd('search', dataSet, username, client, groups, duration);
+};
+
+module.exports = {
+  lookup: lookup,
+  search: search
+};

--- a/src/lib/metrics.js
+++ b/src/lib/metrics.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const moment = require('moment');
+const log = require('./logger');
 const HotShots = require('hot-shots');
 const statsdClient = new HotShots();
 
@@ -83,9 +84,22 @@ const lookup = (dataSet, username, client, groups, startTime, finishTime, id) =>
     throw RangeError('Seventh argument, id, was not a positive integer');
   }
 
+  const reqType = 'lookup';
   const duration = finishTime.diff(startTime);
 
-  statsd('lookup', dataSet, username, client, groups, duration);
+  statsd(reqType, dataSet, username, client, groups, duration);
+
+  const msg = `${username}(${groups.join(',')}) accessed ${dataSet} record ${id} using ${client} in ${duration} ms`;
+
+  log.info({
+    dataSet: dataSet,
+    client: client,
+    groups: groups,
+    id: id,
+    reqType: reqType,
+    responseTime: duration + 'ms',
+    username: username
+  }, msg);
 };
 
 const search = (dataSet, username, client, groups, startTime, finishTime, query) => {
@@ -97,9 +111,24 @@ const search = (dataSet, username, client, groups, startTime, finishTime, query)
     throw TypeError('Seventh argument, query, was not an object');
   }
 
+  const reqType = 'search';
   const duration = finishTime.diff(startTime);
 
-  statsd('search', dataSet, username, client, groups, duration);
+  statsd(reqType, dataSet, username, client, groups, duration);
+
+  const surname = query.surname && query.surname.toUpperCase();
+  const forenames = query.forenames && (query.forenames[0].toUpperCase() + query.forenames.substring(1));
+  const msg = `${username}(${groups.join(',')}) searched ${dataSet} records matching '${forenames} ${surname} ${query.dateOfBirth}' using ${client} in ${duration} ms`;
+
+  log.info({
+    dataSet: dataSet,
+    client: client,
+    groups: groups,
+    query: query,
+    reqType: reqType,
+    responseTime: duration + 'ms',
+    username: username
+  }, msg);
 };
 
 module.exports = {

--- a/src/lib/req-info.js
+++ b/src/lib/req-info.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = (req) => ({
+  username: req.headers['x-auth-username'],
+  client: req.headers['x-auth-aud'],
+  groups: req.headers['x-auth-groups'] && String(req.headers['x-auth-groups']).split(',') || []
+});

--- a/src/middleware/api/v0/events/birth.js
+++ b/src/middleware/api/v0/events/birth.js
@@ -58,7 +58,6 @@ module.exports = {
           if (r) {
             client.increment('lev.api.birth');
             client.increment(`lev.api.${req.headers['x-auth-aud']}`);
-            client.increment(`lev.api.${req.headers['x-auth-aud']}.birth`);
             res.send(censorRecord(r));
             next();
           } else {
@@ -96,7 +95,6 @@ module.exports = {
           .then(r => {
             client.increment('lev.api.birth.search');
             client.increment(`lev.api.${req.headers['x-auth-aud']}`);
-            client.increment(`lev.api.${req.headers['x-auth-aud']}.birth.search`);
             res.send(r.map(censorRecord));
             next();
           })

--- a/src/middleware/api/v0/events/birth.js
+++ b/src/middleware/api/v0/events/birth.js
@@ -5,8 +5,8 @@ const moment = require('moment');
 const promiseRejectionHandler = require('../../../../lib/promise-rejection-handler');
 const audit = require('../../../../model/lev_audit');
 const model = require('../../../../model/birth_registration_v0');
-const StatsD = require('hot-shots');
-const client = new StatsD();
+const metrics = require('../../../../lib/metrics');
+const reqInfo = require('../../../../lib/req-info');
 
 const parseDate = d =>
       d && moment(d, 'YYYY-MM-DD');
@@ -50,15 +50,16 @@ module.exports = {
     } else if (!req.params.id.match(/^\d+$/)) {
       next(new errors.BadRequestError('ID must be an integer'));
     } else {
+      const ri = reqInfo(req);
+      const startTime = moment();
       const id = Number(req.params.id);
 
-      audit.create(req.headers['x-auth-username'], req.headers['x-auth-aud'], req.url)
+      audit.create(ri.username, ri.client, req.url)
         .then(() => model.read(id))
         .then(r => {
           if (r) {
-            client.increment('lev.api.birth');
-            client.increment(`lev.api.${req.headers['x-auth-aud']}`);
             res.send(censorRecord(r));
+            metrics.lookup('birth', ri.username, ri.client, ri.groups, startTime, moment(), id);
             next();
           } else {
             next(new errors.NotFoundError());
@@ -79,6 +80,8 @@ module.exports = {
     } else if (req.query.forenames && req.query.forename1) {
       next(new errors.BadRequestError('Must only provide forenames, or forename1 (plus optionally forename2, 3, and 4)'));
     } else {
+      const ri = reqInfo(req);
+      const startTime = moment();
       const surname = new RegExp('^' + name2regex(req.query.lastname) + '$', 'i');
       const forenames = new RegExp('^' + name2regex(req.query.forenames || [req.query.forename1, req.query.forenames2, req.query.forename3, req.query.forename4].join(' ')) + '(\\s|$)', 'i');
       const dob = parseDate(req.query.dateofbirth);
@@ -86,16 +89,17 @@ module.exports = {
       if (!dob.isValid()) {
         next(new errors.BadRequestError(`Invalid date of birth: '${req.query.dateofbirth}', please use ISO format - e.g. dateofbirth=2000-01-31`));
       } else {
-        audit.create(req.headers['x-auth-username'], req.headers['x-auth-aud'], req.url)
-          .then(() => model.search({
-            dateOfBirth: dob && dob.format('YYYY-MM-DD'),
-            surname: surname,
-            forenames: forenames
-          }))
+        const query = {
+          dateOfBirth: dob && dob.format('YYYY-MM-DD'),
+          surname: surname,
+          forenames: forenames
+        };
+
+        audit.create(ri.username, ri.client, req.url)
+          .then(() => model.search(query))
           .then(r => {
-            client.increment('lev.api.birth.search');
-            client.increment(`lev.api.${req.headers['x-auth-aud']}`);
             res.send(r.map(censorRecord));
+            metrics.search('birth', ri.username, ri.client, ri.groups, startTime, moment(), req.query);
             next();
           })
           .catch(promiseRejectionHandler(next));

--- a/src/middleware/v1/registration/birth.js
+++ b/src/middleware/v1/registration/birth.js
@@ -5,8 +5,8 @@ const moment = require('moment');
 const promiseRejectionHandler = require('../../../lib/promise-rejection-handler');
 const audit = require('../../../model/lev_audit');
 const model = require('../../../model/birth_registration_v1');
-const StatsD = require('hot-shots');
-const client = new StatsD();
+const metrics = require('../../../lib/metrics');
+const reqInfo = require('../../../lib/req-info');
 
 const parseDate = d =>
       d && moment(d, 'YYYY-MM-DD');
@@ -24,15 +24,16 @@ module.exports = {
     } else if (!req.params.id.match(/^\d+$/)) {
       next(new errors.BadRequestError('ID must be an integer'));
     } else {
+      const ri = reqInfo(req);
+      const startTime = moment();
       const id = Number(req.params.id);
 
-      audit.create(req.headers['x-auth-username'], req.headers['x-auth-aud'], req.url)
+      audit.create(ri.username, ri.client, req.url)
         .then(() => model.read(id))
         .then(r => {
           if (r) {
-            client.increment('lev.api.birth');
-            client.increment(`lev.api.${req.headers['x-auth-aud']}`);
             res.send(r);
+            metrics.lookup('birth', ri.username, ri.client, ri.groups, startTime, moment(), id);
             next();
           } else {
             next(new errors.NotFoundError());
@@ -51,6 +52,8 @@ module.exports = {
     } else if (!req.query.dateOfBirth) {
       next(new errors.BadRequestError('Must provide the dateOfBirth parameter'));
     } else {
+      const ri = reqInfo(req);
+      const startTime = moment();
       const surname = new RegExp('^' + name2regex(req.query.surname) + '$', 'i');
       const forenames = new RegExp('^' + name2regex(req.query.forenames) + '(\\s|$)', 'i');
       const dob = parseDate(req.query.dateOfBirth);
@@ -58,16 +61,17 @@ module.exports = {
       if (dob && !dob.isValid()) {
         next(new errors.BadRequestError(`Invalid parameter, dateOfBirth: '${req.query.dateOfBirth}', please use ISO format - e.g. 2000-01-31`));
       } else {
-        audit.create(req.headers['x-auth-username'], req.headers['x-auth-aud'], req.url)
-          .then(() => model.search({
-            dateOfBirth: dob && dob.format('YYYY-MM-DD'),
-            surname: surname,
-            forenames: forenames
-          }))
+        const query = {
+          dateOfBirth: dob && dob.format('YYYY-MM-DD'),
+          surname: surname,
+          forenames: forenames
+        };
+
+        audit.create(ri.username, ri.client, req.url)
+          .then(() => model.search(query))
           .then(r => {
-            client.increment('lev.api.birth.search');
-            client.increment(`lev.api.${req.headers['x-auth-aud']}`);
             res.send(r);
+            metrics.search('birth', ri.username, ri.client, ri.groups, startTime, moment(), req.query);
             next();
           })
           .catch(promiseRejectionHandler(next));

--- a/src/middleware/v1/registration/birth.js
+++ b/src/middleware/v1/registration/birth.js
@@ -32,7 +32,6 @@ module.exports = {
           if (r) {
             client.increment('lev.api.birth');
             client.increment(`lev.api.${req.headers['x-auth-aud']}`);
-            client.increment(`lev.api.${req.headers['x-auth-aud']}.birth`);
             res.send(r);
             next();
           } else {
@@ -68,7 +67,6 @@ module.exports = {
           .then(r => {
             client.increment('lev.api.birth.search');
             client.increment(`lev.api.${req.headers['x-auth-aud']}`);
-            client.increment(`lev.api.${req.headers['x-auth-aud']}.birth.search`);
             res.send(r);
             next();
           })

--- a/src/middleware/v1/registration/death.js
+++ b/src/middleware/v1/registration/death.js
@@ -32,7 +32,6 @@ module.exports = {
           if (r) {
             client.increment('lev.api.death');
             client.increment(`lev.api.${req.headers['x-auth-aud']}`);
-            client.increment(`lev.api.${req.headers['x-auth-aud']}.death`);
             res.send(r);
             next();
           } else {
@@ -68,7 +67,6 @@ module.exports = {
           .then(r => {
             client.increment('lev.api.death.search');
             client.increment(`lev.api.${req.headers['x-auth-aud']}`);
-            client.increment(`lev.api.${req.headers['x-auth-aud']}.death.search`);
             res.send(r);
             next();
           })

--- a/src/middleware/v1/registration/marriage.js
+++ b/src/middleware/v1/registration/marriage.js
@@ -32,7 +32,6 @@ module.exports = {
           if (r) {
             client.increment('lev.api.marriage');
             client.increment(`lev.api.${req.headers['x-auth-aud']}`);
-            client.increment(`lev.api.${req.headers['x-auth-aud']}.marriage`);
             res.send(r);
             next();
           } else {
@@ -68,7 +67,6 @@ module.exports = {
           .then(r => {
             client.increment('lev.api.marriage.search');
             client.increment(`lev.api.${req.headers['x-auth-aud']}`);
-            client.increment(`lev.api.${req.headers['x-auth-aud']}.marriage.search`);
             res.send(r);
             next();
           })

--- a/src/middleware/v1/registration/marriage.js
+++ b/src/middleware/v1/registration/marriage.js
@@ -5,8 +5,8 @@ const moment = require('moment');
 const promiseRejectionHandler = require('../../../lib/promise-rejection-handler');
 const audit = require('../../../model/lev_audit');
 const model = require('../../../model/marriage_registration_v1');
-const StatsD = require('hot-shots');
-const client = new StatsD();
+const metrics = require('../../../lib/metrics');
+const reqInfo = require('../../../lib/req-info');
 
 const parseDate = d =>
       d && moment(d, 'YYYY-MM-DD');
@@ -24,15 +24,16 @@ module.exports = {
     } else if (!req.params.id.match(/^\d+$/)) {
       next(new errors.BadRequestError('ID must be an integer'));
     } else {
+      const ri = reqInfo(req);
+      const startTime = moment();
       const id = Number(req.params.id);
 
-      audit.create(req.headers['x-auth-username'], req.headers['x-auth-aud'], req.url)
+      audit.create(ri.username, ri.client, req.url)
         .then(() => model.read(id))
         .then(r => {
           if (r) {
-            client.increment('lev.api.marriage');
-            client.increment(`lev.api.${req.headers['x-auth-aud']}`);
             res.send(r);
+            metrics.lookup('marriage', ri.username, ri.client, ri.groups, startTime, moment(), id);
             next();
           } else {
             next(new errors.NotFoundError());
@@ -51,6 +52,8 @@ module.exports = {
     } else if (!req.query.dateOfMarriage) {
       next(new errors.BadRequestError('Must provide the dateOfMarriage parameter'));
     } else {
+      const ri = reqInfo(req);
+      const startTime = moment();
       const surname = new RegExp('^' + name2regex(req.query.surname) + '$', 'i');
       const forenames = new RegExp('^' + name2regex(req.query.forenames) + '(\\s|$)', 'i');
       const dom = parseDate(req.query.dateOfMarriage);
@@ -58,16 +61,17 @@ module.exports = {
       if (dom && !dom.isValid()) {
         next(new errors.BadRequestError(`Invalid parameter, dateOfMarriage: '${req.query.dateOfMarriage}', please use ISO format - e.g. 2000-01-31`));
       } else {
-        audit.create(req.headers['x-auth-username'], req.headers['x-auth-aud'], req.url)
-          .then(() => model.search({
-            dateOfMarriage: dom.format('YYYY-MM-DD'),
-            surname: surname,
-            forenames: forenames
-          }))
+        const query = {
+          dateOfMarriage: dom.format('YYYY-MM-DD'),
+          surname: surname,
+          forenames: forenames
+        };
+
+        audit.create(ri.username, ri.client, req.url)
+          .then(() => model.search(query))
           .then(r => {
-            client.increment('lev.api.marriage.search');
-            client.increment(`lev.api.${req.headers['x-auth-aud']}`);
             res.send(r);
+            metrics.search('marriage', ri.username, ri.client, ri.groups, startTime, moment(), req.query);
             next();
           })
           .catch(promiseRejectionHandler(next));

--- a/test/unit/lib/metrics.js
+++ b/test/unit/lib/metrics.js
@@ -5,12 +5,16 @@ const moment = require('moment');
 const hsIncrementStub = sinon.stub();
 const hsSetStub = sinon.stub();
 const hsTimingStub = sinon.stub();
+const logInfoStub = sinon.stub();
 const metrics = proxyquire('../../../src/lib/metrics', {
   'hot-shots': function () {
     this.increment = hsIncrementStub;
     this.set = hsSetStub;
     this.timing = hsTimingStub;
     this.unique = hsSetStub;
+  },
+  './logger': {
+    info: logInfoStub
   }
 });
 
@@ -163,6 +167,17 @@ describe('lib/metrics.js', () => {
             it('calls set on lev.api.req.${dataSet}', () => hsSetStub.should.have.been.calledWith('lev.api.req.birth.users', 'user'));
             it('calls set on lev.api.req.${client}', () => hsSetStub.should.have.been.calledWith('lev.api.req.client.users', 'user'));
             it('calls set on lev.api.req.${group}', () => hsSetStub.should.have.been.calledWith('lev.api.req.group.users', 'user'));
+
+            it('calls log.info', () => logInfoStub.should.have.been.called);
+            it('calls log.info with request information', () => logInfoStub.should.have.been.calledWith({
+              dataSet: 'birth',
+              client: 'client',
+              groups: ['group'],
+              id: 1,
+              reqType: 'lookup',
+              responseTime: responseTime + 'ms',
+              username: 'user'
+            }));
           });
         });
       });
@@ -209,6 +224,17 @@ describe('lib/metrics.js', () => {
         it('calls set on lev.api.req.${dataSet}', () => hsSetStub.should.have.been.calledWith('lev.api.req.birth.users', 'user'));
         it('calls set on lev.api.req.${client}', () => hsSetStub.should.have.been.calledWith('lev.api.req.client.users', 'user'));
         it('calls set on lev.api.req.${group}', () => hsSetStub.should.have.been.calledWith('lev.api.req.group.users', 'user'));
+
+        it('calls log.info', () => logInfoStub.should.have.been.called);
+        it('calls log.info with request information', () => logInfoStub.should.have.been.calledWith({
+          dataSet: 'birth',
+          client: 'client',
+          groups: ['group'],
+          query: {},
+          reqType: 'search',
+          responseTime: responseTime + 'ms',
+          username: 'user'
+        }));
       });
     });
   });

--- a/test/unit/lib/metrics.js
+++ b/test/unit/lib/metrics.js
@@ -1,0 +1,215 @@
+'use strict';
+
+const proxyquire = require('proxyquire');
+const moment = require('moment');
+const hsIncrementStub = sinon.stub();
+const hsSetStub = sinon.stub();
+const hsTimingStub = sinon.stub();
+const metrics = proxyquire('../../../src/lib/metrics', {
+  'hot-shots': function () {
+    this.increment = hsIncrementStub;
+    this.set = hsSetStub;
+    this.timing = hsTimingStub;
+    this.unique = hsSetStub;
+  }
+});
+
+const resetStubs = () => {
+  hsIncrementStub.reset();
+  hsSetStub.reset();
+  hsTimingStub.reset();
+};
+
+const startTime = moment('1970-01-01 00:00:00.000Z');
+const finishTime = moment('1970-01-01 00:00:00.100Z');
+const responseTime = 100;
+
+const requestValidationTest = (subject) => {
+  describe('when called with no arguments', () => {
+    it('throws an error', () => expect(subject).to.throw());
+    it('throws a ReferenceError', () => expect(subject).to.throw(ReferenceError));
+  });
+
+  describe('when called with one argument', () => {
+    describe('that IS NOT a string', () => {
+      it('throws an error', () => expect(() => subject({})).to.throw());
+      it('throws a TypeError', () => expect(() => subject({})).to.throw(TypeError));
+    });
+
+    describe('that IS a string', () => {
+      describe('that IS NOT valid', () => {
+        it('throws an error', () => expect(() => subject('foo')).to.throw());
+        it('throws a RangeError', () => expect(() => subject('foo')).to.throw(RangeError));
+      });
+
+      describe('that IS valid', () => {
+        it('throws an error', () => expect(() => subject('birth')).to.throw());
+        it('throws a ReferenceError', () => expect(() => subject('birth')).to.throw(ReferenceError));
+      });
+    });
+  });
+
+  describe('when called with two arguments', () => {
+    describe('that IS NOT a string', () => {
+      it('throws an error', () => expect(() => subject('birth', {})).to.throw());
+      it('throws a TypeError', () => expect(() => subject('birth', {})).to.throw(TypeError));
+    });
+
+    describe('that IS a string', () => {
+      it('throws an error', () => expect(() => subject('birth', 'user')).to.throw());
+      it('throws a ReferenceError', () => expect(() => subject('birth', 'user')).to.throw(ReferenceError));
+    });
+  });
+
+  describe('when called with three arguments', () => {
+    describe('that IS NOT a string', () => {
+      it('throws an error', () => expect(() => subject('birth', 'user', {})).to.throw());
+      it('throws a TypeError', () => expect(() => subject('birth', 'user', {})).to.throw(TypeError));
+    });
+
+    describe('that IS a string', () => {
+      it('throws an error', () => expect(() => subject('birth', 'user', 'client')).to.throw());
+      it('throws a ReferenceError', () => expect(() => subject('birth', 'user', 'client')).to.throw(ReferenceError));
+    });
+  });
+
+  describe('when called with four arguments', () => {
+    describe('that IS NOT an array', () => {
+      it('throws an error', () => expect(() => subject('birth', 'user', 'client', {})).to.throw());
+      it('throws a TypeError', () => expect(() => subject('birth', 'user', 'client', {})).to.throw(TypeError));
+    });
+
+    describe('that IS an array', () => {
+      it('throws an error', () => expect(() => subject('birth', 'user', 'client', ['group'])).to.throw());
+      it('throws a ReferenceError', () => expect(() => subject('birth', 'user', 'client', ['group'])).to.throw(ReferenceError));
+    });
+  });
+
+  describe('when called with five arguments', () => {
+    describe('that IS NOT a time', () => {
+      it('throws an error', () => expect(() => subject('birth', 'user', 'client', ['group'], {})).to.throw());
+      it('throws a TypeError', () => expect(() => subject('birth', 'user', 'client', ['group'], {})).to.throw(TypeError));
+    });
+
+    describe('that IS a time', () => {
+      it('throws an error', () => expect(() => subject('birth', 'user', 'client', ['group'], startTime)).to.throw());
+      it('throws a ReferenceError', () => expect(() => subject('birth', 'user', 'client', ['group'], startTime)).to.throw(ReferenceError));
+    });
+  });
+
+  describe('when called with six arguments', () => {
+    describe('that IS NOT a time', () => {
+      it('throws an error', () => expect(() => subject('birth', 'user', 'client', ['group'], startTime, {})).to.throw());
+      it('throws a TypeError', () => expect(() => subject('birth', 'user', 'client', ['group'], startTime, {})).to.throw(TypeError));
+    });
+
+    describe('that IS a time', () => {
+      it('throws an error', () => expect(() => subject('birth', 'user', 'client', ['group'], startTime, finishTime)).to.throw());
+      it('throws a ReferenceError', () => expect(() => subject('birth', 'user', 'client', ['group'], startTime, finishTime)).to.throw(ReferenceError));
+    });
+  });
+};
+
+describe('lib/metrics.js', () => {
+  describe('lookup()', () => {
+    const subject = metrics.lookup;
+
+    it('is a function', () => (typeof subject).should.equal('function'));
+    it('takes seven arguments', () => subject.length.should.equal(7));
+
+    requestValidationTest(subject);
+
+    describe('when called with seven arguments', () => {
+      describe('that IS NOT a number', () => {
+        it('throws an error', () => expect(() => subject('birth', 'user', 'client', ['group'], startTime, finishTime, {})).to.throw());
+        it('throws a TypeError', () => expect(() => subject('birth', 'user', 'client', ['group'], startTime, finishTime, {})).to.throw(TypeError));
+      });
+
+      describe('that IS a number', () => {
+        describe('that IS NOT an integer', () => {
+          it('throws an error', () => expect(() => subject('birth', 'user', 'client', ['group'], startTime, finishTime, 3.14)).to.throw());
+          it('throws a TypeError', () => expect(() => subject('birth', 'user', 'client', ['group'], startTime, finishTime, 3.14)).to.throw(TypeError));
+        });
+
+        describe('that IS an integer', () => {
+          describe('that IS negative', () => {
+            it('throws an error', () => expect(() => subject('birth', 'user', 'client', ['group'], startTime, finishTime, -1)).to.throw());
+            it('throws a RangeError', () => expect(() => subject('birth', 'user', 'client', ['group'], startTime, finishTime, -1)).to.throw(RangeError));
+          });
+
+          describe('that IS NOT negative', () => {
+            before(() => {
+              resetStubs();
+              subject('birth', 'user', 'client', ['group'], startTime, finishTime, 1);
+            });
+
+            it('calls increment from the hot-shots library', () => hsIncrementStub.should.have.been.called);
+            it('calls increment on lev.api.req', () => hsIncrementStub.should.have.been.calledWith('lev.api.req'));
+            it('calls increment on lev.api.req.lookup', () => hsIncrementStub.should.have.been.calledWith('lev.api.req.lookup'));
+            it('calls increment on lev.api.req.${dataSet}', () => hsIncrementStub.should.have.been.calledWith('lev.api.req.birth'));
+            it('calls increment on lev.api.req.${client}', () => hsIncrementStub.should.have.been.calledWith('lev.api.req.client'));
+            it('calls increment on lev.api.req.${group}', () => hsIncrementStub.should.have.been.calledWith('lev.api.req.group'));
+
+            it('calls timing from the hot-shots library', () => hsTimingStub.should.have.been.called);
+            it('calls timing on lev.api.req', () => hsTimingStub.should.have.been.calledWith('lev.api.req.time', responseTime));
+            it('calls timing on lev.api.req.lookup', () => hsTimingStub.should.have.been.calledWith('lev.api.req.lookup.time', responseTime));
+            it('calls timing on lev.api.req.${dataSet}', () => hsTimingStub.should.have.been.calledWith('lev.api.req.birth.time', responseTime));
+            it('calls timing on lev.api.req.${client}', () => hsTimingStub.should.have.been.calledWith('lev.api.req.client.time', responseTime));
+            it('calls timing on lev.api.req.${group}', () => hsTimingStub.should.have.been.calledWith('lev.api.req.group.time', responseTime));
+
+            it('calls set from the hot-shots library', () => hsSetStub.should.have.been.called);
+            it('calls set on lev.api.req', () => hsSetStub.should.have.been.calledWith('lev.api.req.users', 'user'));
+            it('calls set on lev.api.req.lookup', () => hsSetStub.should.have.been.calledWith('lev.api.req.lookup.users', 'user'));
+            it('calls set on lev.api.req.${dataSet}', () => hsSetStub.should.have.been.calledWith('lev.api.req.birth.users', 'user'));
+            it('calls set on lev.api.req.${client}', () => hsSetStub.should.have.been.calledWith('lev.api.req.client.users', 'user'));
+            it('calls set on lev.api.req.${group}', () => hsSetStub.should.have.been.calledWith('lev.api.req.group.users', 'user'));
+          });
+        });
+      });
+    });
+  });
+
+  describe('search()', () => {
+    const subject = metrics.search;
+
+    it('is a function', () => (typeof subject).should.equal('function'));
+    it('takes seven arguments', () => subject.length.should.equal(7));
+
+    requestValidationTest(subject);
+
+    describe('when called with seven arguments', () => {
+      describe('that IS NOT an object', () => {
+        it('throws an error', () => expect(() => subject('birth', 'user', 'client', ['group'], startTime, finishTime, '')).to.throw());
+        it('throws a TypeError', () => expect(() => subject('birth', 'user', 'client', ['group'], startTime, finishTime, '')).to.throw(TypeError));
+      });
+
+      describe('that IS an object', () => {
+        before(() => {
+          resetStubs();
+          subject('birth', 'user', 'client', ['group'], startTime, finishTime, {});
+        });
+
+        it('calls increment from the hot-shots library', () => hsIncrementStub.should.have.been.called);
+        it('calls increment on lev.api.req', () => hsIncrementStub.should.have.been.calledWith('lev.api.req'));
+        it('calls increment on lev.api.req.search', () => hsIncrementStub.should.have.been.calledWith('lev.api.req.search'));
+        it('calls increment on lev.api.req.${dataSet}', () => hsIncrementStub.should.have.been.calledWith('lev.api.req.birth'));
+        it('calls increment on lev.api.req.${client}', () => hsIncrementStub.should.have.been.calledWith('lev.api.req.client'));
+        it('calls increment on lev.api.req.${group}', () => hsIncrementStub.should.have.been.calledWith('lev.api.req.group'));
+
+        it('calls timing from the hot-shots library', () => hsTimingStub.should.have.been.called);
+        it('calls timing on lev.api.req', () => hsTimingStub.should.have.been.calledWith('lev.api.req.time', responseTime));
+        it('calls timing on lev.api.req.search', () => hsTimingStub.should.have.been.calledWith('lev.api.req.search.time', responseTime));
+        it('calls timing on lev.api.req.${dataSet}', () => hsTimingStub.should.have.been.calledWith('lev.api.req.birth.time', responseTime));
+        it('calls timing on lev.api.req.${client}', () => hsTimingStub.should.have.been.calledWith('lev.api.req.client.time', responseTime));
+        it('calls timing on lev.api.req.${group}', () => hsTimingStub.should.have.been.calledWith('lev.api.req.group.time', responseTime));
+
+        it('calls set from the hot-shots library', () => hsSetStub.should.have.been.called);
+        it('calls set on lev.api.req', () => hsSetStub.should.have.been.calledWith('lev.api.req.users', 'user'));
+        it('calls set on lev.api.req.search', () => hsSetStub.should.have.been.calledWith('lev.api.req.search.users', 'user'));
+        it('calls set on lev.api.req.${dataSet}', () => hsSetStub.should.have.been.calledWith('lev.api.req.birth.users', 'user'));
+        it('calls set on lev.api.req.${client}', () => hsSetStub.should.have.been.calledWith('lev.api.req.client.users', 'user'));
+        it('calls set on lev.api.req.${group}', () => hsSetStub.should.have.been.calledWith('lev.api.req.group.users', 'user'));
+      });
+    });
+  });
+});


### PR DESCRIPTION
Refactors the current StatsD metrics support into a dedicated library.
Also adds new metrics for:
* breaking down by group and request type
* combining all requests for data
* tracking who's using the service
* tracking how long requests for data take to fulfil

This refactor should make it much easier to add new channels for metrics
in the future.