### PR TITLE
Automate version changes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ matrix:
   MINOR:
     - 6
   PATCH:
-    - 1
+    - 2
   DOCKER_USERNAME:
     - ukhomeofficedigital+lev_api
   DOCKER_REPO:

--- a/.version.js
+++ b/.version.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+const drone = '.drone.yml';
+const config = fs.readFileSync(drone, { encoding: 'utf8' });
+const [major, minor, patch] = require('./package.json').version.split('.');
+
+fs.writeFileSync(drone, config.replace(
+  /^(.*MAJOR:\s*- )\d+(\s*MINOR:\s*- )\d+(\s*PATCH:\s*- )\d+(.*)$/m, `$1${major}$2${minor}$3${patch}$4`));

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:check-coverage": "nyc check-coverage --statements 0 --branches 0 --functions 0 --lines 0",
     "snyk-protect": "snyk protect",
     "postinstall": "npm run snyk-protect",
-    "prepublish": "npm run snyk-protect"
+    "prepublish": "npm run snyk-protect",
+    "version": "./.version.js && git add .drone.yml"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lev-api",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Life Event Verification API",
   "main": "src/app.js",
   "scripts": {


### PR DESCRIPTION
Provides a way to automatically handle all the necessary changes needed to update the version of the API. Simply run one of the following commands (as appropriate):
 - `npm version patch`
 - `npm version minor`
 - `npm version major`
...to update the `package.json` and `.drone.yml` versions, commit the changes, and create a git tag of the new version.