### PR TITLE
Fix: Fuzzier matching on network names in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,10 @@ deps: docker-test-deps node-deps
 docker-compose-deps:
 	docker-compose pull
 
-docker-test-deps: docker-compose-deps
+docker-test-deps:
 	docker pull '$(test_image)'
 	docker pull '$(perf_test_image)'
+	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' pull
 
 node-deps: node_modules/
 
@@ -56,10 +57,7 @@ docker-test: docker-test-deps docker
 	docker run -d --name 'lev-api-mock' --env 'MOCK=true' '$(DOCKER_IMAGE)'
 	docker run --net 'container:lev-api-mock' --env 'TEST_URL=http://localhost:8080' --env 'WAIT=true' '$(test_image)'
 	docker stop 'lev-api-mock'
-	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' stop
-	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' rm -vfs
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' down -v
-	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' pull
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' build
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' up &> /dev/null &
 	compose_network=`$(probe_network)`; \

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
 
 compose_project_name = $(current_dir)
-compose_network != echo "$$(echo '$(compose_project_name)' | tr -d '[\-_]')_default"
-probe_network = docker network ls | grep -q '$(compose_network)'
+compose_network_regexp != echo "$$(echo '$(compose_project_name)' | sed -E 's/([-_])+/[-_]*/g')_default"
+probe_network = docker network ls | grep -o '$(compose_network_regexp)'
 
 .PHONY: all clean deps distclean docker docker-clean docker-compose docker-compose-clean docker-compose-deps docker-test docker-test-deps node-deps run test unit-test
 
@@ -62,14 +62,14 @@ docker-test: docker-test-deps docker
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' pull
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' build
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' up &> /dev/null &
-	eval $(probe_network); \
+	compose_network=`$(probe_network)`; \
 	while [ $$? -ne 0 ]; do \
 		echo ...; \
 		sleep 5; \
-		eval $(probe_network); \
-	done; true
-	docker run --net '$(compose_network)' --env 'TEST_URL=http://api:8080' --env 'WAIT=true' '$(test_image)'
-	docker run --net '$(compose_network)' --env "TEST_CONFIG=$$(cat ./test/perf/artillery.config.yml)" --env "MEDIAN_LATENCY=50" '$(perf_test_image)'
+		compose_network=`$(probe_network)`; \
+	done; \
+	docker run --net "$${compose_network}" --env 'TEST_URL=http://api:8080' --env 'WAIT=true' '$(test_image)' && \
+	docker run --net "$${compose_network}" --env "TEST_CONFIG=$$(cat ./test/perf/artillery.config.yml)" --env "MEDIAN_LATENCY=50" '$(perf_test_image)'
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' down -v
 
 docker-compose-clean:


### PR DESCRIPTION
As the network name now needs to be determined based on the output of
grep we now store it in a Bash variable rather than a Make variable.