### PR TITLE
Remove unnecessary chown from build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ USER root
 RUN apk del --no-cache \
       g++ \
       make \
-      python \
- && chown -R app:app .
+      python
 
 USER 31337
 ENV LISTEN_HOST="0.0.0.0" \


### PR DESCRIPTION
Speeds up the build be removing a very slow and unnecessary chown. This
change will mean that some files will be owned by root but this should
be fine.