### PR TITLE
[LEVWEB-1178] Add support for Prometheus metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "moment": "^2.22.1",
     "pg-monitor": "^1.0.0",
     "pg-promise": "^8.4.4",
+    "prom-client": "^11.2.1",
     "restify": "^7.2.0",
     "restify-bunyan-logger": "^2.0.7",
     "restify-errors": "^6.1.0",

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@
 const config = require('../config.js');
 const log = require('./lib/logger');
 const healthCheck = require('./middleware/health-check');
+const metrics = require('./middleware/metrics');
 const v0Birth = require('./middleware/api/v0/events/birth');
 const v0UserActivity = require('./middleware/api/v0/audit/user-activity');
 const v1Birth = require('./middleware/v1/registration/birth');
@@ -35,6 +36,7 @@ httpd.use((req, res, next) => {
 httpd.on('after', restifyBunyanLogger());
 
 httpd.get('/healthz', healthCheck.liveness);
+httpd.get('/metrics', metrics);
 httpd.get('/readiness', healthCheck.readiness);
 httpd.get('/api/v0/events/birth/:id', v0Birth.read);
 httpd.get('/api/v0/events/birth', v0Birth.search);

--- a/src/middleware/metrics.js
+++ b/src/middleware/metrics.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const metrics = require('../lib/metrics');
+const register = metrics.prometheus.register;
+
+module.exports = (req, res, next) => {
+  res.set('Content-Type', register.contentType);
+  res.end(register.metrics());
+};

--- a/test/unit/lib/metrics.js
+++ b/test/unit/lib/metrics.js
@@ -156,6 +156,7 @@ describe('lib/metrics.js', () => {
           describe('that IS NOT negative', () => {
             before(() => {
               resetStubs();
+              metrics.prometheus.register.resetMetrics();
               subject('birth', 'user', 'client', ['group'], ['role'], startTime, finishTime, 1);
             });
 
@@ -179,6 +180,12 @@ describe('lib/metrics.js', () => {
             it('calls set on lev.api.req.${dataSet}', () => hsSetStub.should.have.been.calledWith('lev.api.req.birth.users', 'user'));
             it('calls set on lev.api.req.${client}', () => hsSetStub.should.have.been.calledWith('lev.api.req.client.users', 'user'));
             it('calls set on lev.api.req.${group}', () => hsSetStub.should.have.been.calledWith('lev.api.req.group.users', 'user'));
+
+            it('increments the Prometheus counter lev_api_req', () => metrics.prometheus.register.getSingleMetricAsString('req').should.match(/[^0-9]1$/));
+            it('increments the Prometheus counter lev_api_req_birth', () => metrics.prometheus.register.getSingleMetricAsString('req_birth').should.match(/[^0-9]1$/));
+            it('increments the Prometheus counter lev_api_req_client', () => metrics.prometheus.register.getSingleMetricAsString('req_client').should.match(/[^0-9]1$/));
+            it('increments the Prometheus counter lev_api_req_group', () => metrics.prometheus.register.getSingleMetricAsString('req_group').should.match(/[^0-9]1$/));
+            it('increments the Prometheus counter lev_api_req_lookup', () => metrics.prometheus.register.getSingleMetricAsString('req_lookup').should.match(/[^0-9]1$/));
 
             it('calls log.info', () => logInfoStub.should.have.been.called);
             it('calls log.info with request information', () => logInfoStub.should.have.been.calledWith({
@@ -213,6 +220,7 @@ describe('lib/metrics.js', () => {
       describe('that IS an object', () => {
         before(() => {
           resetStubs();
+          metrics.prometheus.register.resetMetrics();
           subject('birth', 'user', 'client', ['group'], ['role'], startTime, finishTime, {});
         });
 
@@ -236,6 +244,12 @@ describe('lib/metrics.js', () => {
         it('calls set on lev.api.req.${dataSet}', () => hsSetStub.should.have.been.calledWith('lev.api.req.birth.users', 'user'));
         it('calls set on lev.api.req.${client}', () => hsSetStub.should.have.been.calledWith('lev.api.req.client.users', 'user'));
         it('calls set on lev.api.req.${group}', () => hsSetStub.should.have.been.calledWith('lev.api.req.group.users', 'user'));
+
+        it('increments the Prometheus counter lev_api_req', () => metrics.prometheus.register.getSingleMetricAsString('req').should.match(/[^0-9]1$/));
+        it('increments the Prometheus counter lev_api_req_birth', () => metrics.prometheus.register.getSingleMetricAsString('req_birth').should.match(/[^0-9]1$/));
+        it('increments the Prometheus counter lev_api_req_client', () => metrics.prometheus.register.getSingleMetricAsString('req_client').should.match(/[^0-9]1$/));
+        it('increments the Prometheus counter lev_api_req_group', () => metrics.prometheus.register.getSingleMetricAsString('req_group').should.match(/[^0-9]1$/));
+        it('increments the Prometheus counter lev_api_req_search', () => metrics.prometheus.register.getSingleMetricAsString('req_search').should.match(/[^0-9]1$/));
 
         it('calls log.info', () => logInfoStub.should.have.been.called);
         it('calls log.info with request information', () => logInfoStub.should.have.been.calledWith({


### PR DESCRIPTION
Adds support for Prometheus metrics which are available on the new
`/metrics` endpoint.