### PR TITLE
De-dup GSI accounts in audit response

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:cover": "nyc --all npm run test:unit && nyc report --reporter=html",
     "test:check-coverage": "nyc check-coverage --statements 0 --branches 0 --functions 0 --lines 0",
     "snyk-protect": "snyk protect",
-    "postinstall": "npm run snyk-protect",
+    "postinstall": "true",
     "prepublish": "npm run snyk-protect"
   },
   "repository": {

--- a/src/model/lev_audit/postgres.js
+++ b/src/model/lev_audit/postgres.js
@@ -17,7 +17,7 @@ module.exports = {
     const operationFragment = operation ? ' AND operation = $5' : '';
     const datasetFragment = dataset ? ' AND dataset = $6' : '';
 
-    return postgres.any('SELECT username, date_time::date AS date, count(*) AS count FROM lev_audit WHERE date_time::date >= $1 AND date_time::date <= $2' + usernameFragment + groupFragment + operationFragment + datasetFragment + ' GROUP BY username, date', [start, finish, username, [group], operation, dataset])
+    return postgres.any('SELECT regexp_replace(username, \'.gsi.gov.uk$\', \'.gov.uk\') as username, date_time::date AS date, count(*) AS count FROM lev_audit WHERE date_time::date >= $1 AND date_time::date <= $2' + usernameFragment + groupFragment + operationFragment + datasetFragment + ' GROUP BY 1, date', [start, finish, username, [group], operation, dataset])
       .then(r => r.reduce(reduce2Object, {}));
   }
 };


### PR DESCRIPTION
Uses regex to remove GSI from e-mail addresses in the audit response so
that we can report without including any duplicates.

This change can be reverted once this month's reports have been
produced.