### PR TITLE
Run the correct version of the functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@ DOCKER_IMAGE ?= lev-api
 patch_version != jq -r '.version' 'package.json'
 minor_version != echo "$(patch_version)" | awk -F '.' '{print $$1"."$$2}'
 
-#test_image = quay.io/ukhomeofficedigital/lev-api-test:$(minor_version)
-test_image = quay.io/ukhomeofficedigital/lev-api-test:0.14
+test_image = quay.io/ukhomeofficedigital/lev-api-test:$(minor_version)
 perf_test_image = quay.io/ukhomeofficedigital/artillery-ci:0.2
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))


### PR DESCRIPTION
Up until now, we have been using `latest` but really we should test against the specification that we are claiming to have fulfilled.