### PR TITLE
[LEVWEB-1396] fix: Push to correct Docker tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ matrix:
   MAJOR:
     - 0
   MINOR:
-    - 12
+    - 15
   PATCH:
     - 0
   DOCKER_USERNAME:


### PR DESCRIPTION
We were still pushing to the 0.12 docker tag when we should have been on 0.15.