### PR TITLE
chore: Try to prevent errors in e2e tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -68,6 +68,7 @@ pipeline:
       - $${kubectl} set image "deployment/$${KUBE_DEPLOYMENT}" "$${KUBE_CONTAINER}=${DOCKER_REPO}/${NAME}:$${TAG}"
       - $${kubectl} rollout status "deployment/$${KUBE_DEPLOYMENT}"
       - $${kubectl} scale deployment "$${KUBE_DEPLOYMENT}" --replicas 1
+      - sleep 30
       - set -o pipefail
       - docker run --env "USERNAME=$${USERNAME}" --env "PASSWORD=$${PASSWORD}" --env "CLIENT_ID=$${CLIENT_ID}" --env "CLIENT_SECRET=$${CLIENT_SECRET}" --env "OIDC_URL=$${OIDC_URL}" --env "TEST_URL=$${TEST_URL}" quay.io/ukhomeofficedigital/lev-api-test:${MAJOR}.${MINOR} | tee 'e2e.log'
       - $${kubectl} annotate --overwrite deployment "$${KUBE_DEPLOYMENT}" lev-api-test-log="`cat test.log e2e.log`"


### PR DESCRIPTION
We are getting 502s when doing end-to-end tests. Let's try the ugly hack we use in lev-web and see if it helps.