### PR TITLE
LEV-105: new jenkins slave

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:16-alpine
 
+ENV HTTP_PROXY='http://proxy.local:8080'
+ENV HTTPS_PROXY='http://proxy.local:8080'
+
 RUN apk add --no-cache \
       ca-certificates \
       g++ \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-        identifier: 'jenkins-shared@master',
+        identifier: 'jenkins-shared@lev-105-jenkins-slave',
         retriever: modernSCM([$class       : 'GitSCMSource',
                               remote       : 'ssh://git@bitbucket.ipttools.info/lev/jenkins-shared.git',
                               credentialsId: 'git'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-        identifier: 'jenkins-shared@lev-105-jenkins-slave',
+        identifier: 'jenkins-shared@master',
         retriever: modernSCM([$class       : 'GitSCMSource',
                               remote       : 'ssh://git@bitbucket.ipttools.info/lev/jenkins-shared.git',
                               credentialsId: 'git'])


### PR DESCRIPTION
LEV-API now refers to an updated `pipelineNodeJSApp` from `jenkins-shared` which runs the full "test" suite from the lev-api `Makefile` - this change introduced the ability of running all component integration tests (using docker-compose) on LEV's jenkins instance in EBSA